### PR TITLE
Build container image with Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,6 +40,11 @@ rec {
     '';
   };
 
+  app-bin = writeShellScriptBin "server" ''
+    export PYTHONPATH="${app}:$PYTHONPATH"
+    exec ${python-env}/bin/gunicorn app:server -w4
+  '';
+
   python-env = pkgs.python3.buildEnv.override {
     extraLibs = [
       dash

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,65 @@
+# if you have Nix installed,
+# this will provide a development environment for you via `nix-shell`
+with import (fetchTarball https://releases.nixos.org/nixos/21.05/nixos-21.05.3761.93ca5ab64f7/nixexprs.tar.xz) {};
+with pkgs.python38Packages;
+let
+  dash_bootstrap_components = buildPythonPackage rec {
+      pname = "dash-bootstrap-components";
+      version = "0.13.1";
+
+      propagatedBuildInputs = [dash];
+      src = fetchPypi {
+        inherit pname version;
+        sha256 = "02p77b4g8cn4g49a3kyam9sjqgjzcjsvzxqgrk0ml07cgg1pbb84";
+      };
+
+      doCheck = false;
+  };
+
+  dash_daq = buildPythonPackage rec {
+      pname = "dash_daq";
+      version = "0.5.0";
+
+      propagatedBuildInputs = [dash];
+      /* src = fetchTarball https://github.com/plotly/dash-daq/archive/v0.5.0.tar.gz; */
+      src = fetchPypi {
+        inherit pname version;
+        sha256 = "0si5wjnl5sxy8fwm1lx82r32ahccnnyswi5w5xjqbf7pk5kmpn51";
+      };
+
+      doCheck = true;
+  };
+in
+rec {
+  app = pkgs.stdenv.mkDerivation {
+    name = "SemiconductorsApp";
+    version = "1.0";
+    src = ./.;
+    installPhase = ''
+      cp -R $src $out
+    '';
+  };
+
+  python-env = pkgs.python3.buildEnv.override {
+    extraLibs = [
+      dash
+      dash_bootstrap_components
+      dash_daq
+
+      joblib
+      scipy
+      pandas
+      flake8
+      gunicorn
+    ];
+  };
+
+  image = pkgs.dockerTools.streamLayeredImage {
+    name = "semiconductorsapp";
+    tag = "latest";
+    config = {
+      Cmd = [ "${python-env}/bin/gunicorn" "app:server" "-w4" ];
+      WorkingDir = "${app}";
+    };
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,34 +1,8 @@
 # if you have Nix installed,
 # this will provide a development environment for you via `nix-shell`
 with import (fetchTarball https://releases.nixos.org/nixos/21.05/nixos-21.05.3761.93ca5ab64f7/nixexprs.tar.xz) {};
-with pkgs.python38Packages;
 let
-  dash_bootstrap_components = buildPythonPackage rec {
-      pname = "dash-bootstrap-components";
-      version = "0.13.1";
-
-      propagatedBuildInputs = [dash];
-      src = fetchPypi {
-        inherit pname version;
-        sha256 = "02p77b4g8cn4g49a3kyam9sjqgjzcjsvzxqgrk0ml07cgg1pbb84";
-      };
-
-      doCheck = false;
-  };
-
-  dash_daq = buildPythonPackage rec {
-      pname = "dash_daq";
-      version = "0.5.0";
-
-      propagatedBuildInputs = [dash];
-      /* src = fetchTarball https://github.com/plotly/dash-daq/archive/v0.5.0.tar.gz; */
-      src = fetchPypi {
-        inherit pname version;
-        sha256 = "0si5wjnl5sxy8fwm1lx82r32ahccnnyswi5w5xjqbf7pk5kmpn51";
-      };
-
-      doCheck = true;
-  };
+  pythonEnv = (import ./default.nix).python-env;
 in
 pkgs.mkShell {
   shellHook = ''
@@ -36,14 +10,6 @@ pkgs.mkShell {
     '';
 
   buildInputs = [
-    dash
-    dash_bootstrap_components
-    dash_daq
-
-    joblib
-    scipy
-    pandas
-    gunicorn
-    flake8
+    pythonEnv
   ];
 }


### PR DESCRIPTION
This PR introduces a new file `default.nix` containing all the information needed to build a container image for deployment via Nix.

To build an image:
`nix-build -A image`

And here's a one-liner to push the image to a container registry:
`$(nix-build -A image) | gzip --fast | skopeo copy docker-archive:/dev/stdin docker://$IMAGE_REGISTRY/semiconductorsapp:latest`

:tada: